### PR TITLE
fix: reduce status_display_manager frequency

### DIFF
--- a/src/status_display_manager.cpp
+++ b/src/status_display_manager.cpp
@@ -98,7 +98,7 @@ void StatusDisplayManager::callbackStateMessage(
 
     RCLCPP_INFO_THROTTLE(
       this->get_logger(),
-      *this->get_clock(), 1.0,
+      *this->get_clock(), 5000.0,
       "[StatusDisplayManager::callbackStateMessage]"
       "service_layer_state: %u, control_layer_state: %u",
       msg->service_layer_state,
@@ -115,7 +115,7 @@ void StatusDisplayManager::callbackDiagStateMessage(
     if (status.name == "/autoware/vehicle/obstacle_crash") {
       RCLCPP_INFO_THROTTLE(
         this->get_logger(),
-        *this->get_clock(), 1.0,
+        *this->get_clock(), 5000.0,
         "[StatusDisplayManager::callbackDiagStateMessage]"
         "name: %s, level: %u",
         status.name.c_str(),
@@ -142,7 +142,7 @@ void StatusDisplayManager::callbackVehicleTurnMessage(
     std::unique_lock<std::mutex> lock(indicators_mutex_);
     RCLCPP_INFO_THROTTLE(
       this->get_logger(),
-      *this->get_clock(), 1.0,
+      *this->get_clock(), 5000.0,
       "[StatusDisplayManager::callbackVehicleTurnMessage]"
       "vehicle_turn_status: %u",
       msg.report);


### PR DESCRIPTION
## Description

* Reduce the logging frequency of status_display_manager

## Related links

* Jira ticket: https://tier4.atlassian.net/browse/AEAP-1967

## Tests performed

* Launch the Psim and copy the log into log file
```
$ ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=${VEHICLE_MODEL} sensor_model:=${SENSOR_MODEL} map_path:=${HOME}/map pointcloud_map_file:=pointcloud_map.pcd rviz_config:=autoware.rviz > before.log
```
* Set initial position and wait for about 1 minute
* Check the log file
```
$ cat before.log | grep status_display_manager
```
### result
* before.log: status_display_manager print the callback message every 0.02~0.03 seconds
```
[status_display_manager-54] [INFO 1732873035.141232089] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732873035.166677071] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732873035.191537444] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732873035.216175083] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732873035.241009690] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732873035.266217729] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732873035.291544403] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
```
* after.log:  status_display_manager print the callback message every 5 seconds
```
[status_display_manager-54] [INFO 1732876272.287097918] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876277.311538163] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876282.336294795] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876287.336432749] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876292.361747737] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876297.386101715] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876302.386625092] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876307.410999042] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876312.410999924] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876317.411210141] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876322.435713855] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[status_display_manager-54] [INFO 1732876327.461183385] [status_display_manager] callbackVehicleTurnMessage(): [StatusDisplayManager::callbackVehicleTurnMessage]vehicle_turn_status: 0
[INFO] [status_display_manager-54]: process has finished cleanly [pid 715464]
```
[before.log](https://github.com/user-attachments/files/17957395/before.log)
[after.log](https://github.com/user-attachments/files/17958497/after.log)




## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/